### PR TITLE
Improve syntax for vox files

### DIFF
--- a/conf.lua
+++ b/conf.lua
@@ -1,6 +1,6 @@
 function love.conf(t)
 	t.identity = "Lovox demo"
-	t.version  = "0.10.1"
+	t.version  = "11.0"
 	t.console  = false
 
 	t.window.title  = "Lovox demo"

--- a/lovox/modelData.lua
+++ b/lovox/modelData.lua
@@ -123,9 +123,9 @@ local function new(source, w, h)
    local t = type(source)
 
    if t == "string" then
-      if love.filesystem.isDirectory(source) then
+      if love.filesystem.getInfo(source).type == 'directory' then
          return newFromPath(source)
-      elseif love.filesystem.isFile(source) then
+      elseif love.filesystem.getInfo(source).type == 'file' then
          return newFromVox(source)
       end
    elseif t == "userdata" then

--- a/lovox/modelData.lua
+++ b/lovox/modelData.lua
@@ -90,7 +90,8 @@ end
 
 -- Generates new ModelData from a .vox
 -- !! This function is very slow. Only use it for testing !!
-local function newFromVox(file)
+local function newFromVox(path)
+   local file = love.filesystem.newFile(path)
    file:open("r")
 		local model = Vox_model.new(file:read())
 	file:close()
@@ -121,9 +122,17 @@ end
 local function new(source, w, h)
    local t = type(source)
 
-   if     t == "string"   then return newFromPath(source)
-   elseif t == "userdata" then return newFromImage(source, w, h)
-   elseif t == "function" then return newFromFunc(source, w, h) end
+   if t == "string" then
+      if love.filesystem.isDirectory(source) then
+         return newFromPath(source)
+      elseif love.filesystem.isFile(source) then
+         return newFromVox(source)
+      end
+   elseif t == "userdata" then
+      return newFromImage(source, w, h)
+   elseif t == "function" then
+      return newFromFunc(source, w, h)
+   end
 
    error("Wrong source type. Expected 'string' or 'userdata' or 'function'. Got '"..t.."'.")
 end

--- a/lovox/vox2png/vox_texture.lua
+++ b/lovox/vox2png/vox_texture.lua
@@ -4,7 +4,8 @@ local function getPoints(model)
   local points, len = {}, 0
   for _,voxel in ipairs(model.voxels) do
     len = len + 1
-    local color = model.palette[voxel[4]]
+    local color8 = model.palette[voxel[4]]
+    local color = {color8[1]/255, color8[2]/255, color8[3]/255, color8[4]/255}
     local x,y,z = voxel[1], voxel[2], voxel[3]
     points[len] = { z * model.sizeX + x + 0.5,
                     y + 0.5,

--- a/main.lua
+++ b/main.lua
@@ -33,8 +33,7 @@ Cube:play()
 
 -- Load a model from a .vox
 -- !! Slow !!
-local vox = love.filesystem.newFile("barrier_bend.vox")
-local BarrierData = ModelData.newFromVox(vox) -- newFromVox is required here.
+local BarrierData = ModelData('barrier_bend.vox') -- newFromVox is required here.
 local Barrier     = Model(BarrierData)
 
 function love.update(dt)


### PR DESCRIPTION
This change makes the library detect whether a string is a path (to call newFromPath) or a file (to call newFromVox). This way the syntax for importing is the same for both methods.